### PR TITLE
Fix early return bug of "Toggle checks for current note" command only enable and does not (display) disable.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -37,19 +37,19 @@ const writeGoodPlugin = ViewPlugin.fromClass(
         }
 
         #redecorate(update: any): void {
-			if (update.docChanged || update.focusChanged) {
-				this.decorations = this.#buildDecorations();
-				return;
-			}
+            const hasTriggerEffect = update.transactions.some((tr: Transaction) =>
+                tr.effects.some((e: StateEffect<null>) => e.is(TriggerWriteGoodChecksStateEffect))
+            );
 
-			const hasTriggerEffect = update.transactions.some((tr: Transaction) =>
-				tr.effects.some((e: StateEffect<null>) => e.is(TriggerWriteGoodChecksStateEffect))
-			);
+            // 1. Always update the state if the toggle was pressed
+            if (hasTriggerEffect) {
+                this.checksEnabled = this.#fileChecksEnabled();
+            }
 
-			if (hasTriggerEffect) {
-				this.checksEnabled = this.#fileChecksEnabled();
-				this.decorations = this.#buildDecorations();
-			}
+            // 2. Redraw the decorations if the document changed, focus changed, OR the toggle was pressed
+            if (update.docChanged || update.focusChanged || hasTriggerEffect) {
+                this.decorations = this.#buildDecorations();
+            }
         }
 
         #fileChecksEnabled(): boolean {


### PR DESCRIPTION
Problem: When the "Toggle checks for current note" command is run via the Obsidian Command Palette, the editor briefly loses and regains focus. Because opening the command palette triggers a `focusChanged` event, the code hits the if block, rebuilds the decorations using the old cached `this.checksEnabled` setting, and then hits return;. It completely skips the code that tells it to fetch the new toggled state.

Plugin successfully saved the disabling linting decision in the background, but the code editor refuses to refresh its visuals to hide the highlights.

Current workaround if not update:
1. Run the "Toggle checks for current note" command to disable it.
2. Close the note and reopen it. 
3. When the note reopens, the plugin will load fresh and read the correct disabled state, and the highlights will be gone.